### PR TITLE
Add Docker compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# build environment
+FROM node:12-alpine as build
+LABEL maintainer="build@lecturegoggles.io"
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:$PATH
+COPY package.json /app/package.json
+RUN npm install
+COPY . /app
+RUN npm run build
+
+# production environment
+FROM nginx:mainline-alpine
+RUN rm -rf /usr/share/nginx/html/*
+
+COPY --from=build /app/build /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This Docker image should only be run AFTER an upstream server (we use Azure Front Door) terminates SSL.